### PR TITLE
fix: update spec and readme regarding delegation of storage sub-paths

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ A capability object looks like this:
 
 The `with` field specifies the **resource pointer**, which in the case of UCAN.Storage is a string that includes the DID of the user to whom the token was issued. A `storage` resource pointer issued by a service that supports UCAN.Storage will always begin with the `storage://` prefix, followed by the DID that the token was issued to (the "audience" of the token).
 
-When deriving child tokens for a new user, you should append the DID of the new user to the resource path, with `/` characters separating the DID strings. For example, if your DID is `did:key:marketplace`, the token issued by the storage service would have the resource `storage://did:key:marketplace`. If you then issue a token to a user with the DID `did:key:user-1`, the new token should have a resource path of `storage://did:key:marketplace/did:key:user-1`.
+When deriving child tokens for a new user, you will probably want to restrict that user's access to a sub-path of your storage. A simple way to do this is to append the DID of the new user to the resource path, with `/` characters separating the DID strings. For example, if your DID is `did:key:marketplace`, the token issued by the storage service would have the resource `storage://did:key:marketplace`. You can then issue a token to a user with the DID `did:key:user-1` and a resource path of `storage://did:key:marketplace/did:key:user-1`.
 
 The `can` field specifies what **action** the token holder is authorized to perform. UCAN.Storage currently supports two actions, `upload/*` and `upload/IMPORT`.
 

--- a/spec.md
+++ b/spec.md
@@ -93,7 +93,7 @@ The resource pointer MUST match the current proof scope. Meaning it will follow 
 
 When a [Service](#21-Service) issues a UCAN for `did:user1` the resource will be `storage://did:user-1`, if `user-1` issues a delegated UCAN to `did:user-2` it MAY further restrict the scope of it by setting the resource to `storage://did:user-1/did:user-2/`.
 
-When restricting the issuer MUST add another path segment to the resource URI. Using audience DID will guarantee uniqueness, although it is not REQUIRED to be unique and could be anything i.e. `storage://did:user-1/public`.
+When restricting, the issuer can OPTIONALLY add another path segment to the resource URI. Using audience DID will guarantee uniqueness, although it is not REQUIRED to be unique and could be anything i.e. `storage://did:user-1/public`.
 
 <!--
 > We avoid name collisions simply by treating `/` terminated paths as directories and non `/` terminated as files.


### PR DESCRIPTION
* From [discussion on PR 3](https://github.com/nftstorage/ucan.storage/pull/3#discussion_r819716757): tweak spec to say that adding a sub-path when issuing a child UCAN.
* Similarly, update README to make it clear that it's not a _requirement_ to delegate a sub-path based on a user's DID.