### PR TITLE
fix: rename global constants to avoid collisions

### DIFF
--- a/src/ucan.js
+++ b/src/ucan.js
@@ -8,8 +8,8 @@ import {
   isTooEarly,
 } from './utils.js'
 
-const TYPE = 'JWT'
-const VERSION = '0.8.0'
+const _TOKEN_TYPE = 'JWT'
+const _UCAN_VERSION = '0.8.0'
 
 export { KeyPair } from './keypair.js'
 
@@ -78,8 +78,8 @@ export async function sign(payload, keypair) {
   /** @type {import('./types').UcanHeader} */
   const header = {
     alg: 'EdDSA',
-    typ: TYPE,
-    ucv: VERSION,
+    typ: _TOKEN_TYPE,
+    ucv: _UCAN_VERSION,
   }
 
   // Encode parts


### PR DESCRIPTION
This just renames the `TYPE` and `VERSION` constants to avoid the [odd issue I was experiencing in nft.storage](https://github.com/nftstorage/nft.storage/pull/1914#issuecomment-1129200445), where the `VERSION` constant defined here was showing up in the global scope at runtime in the nft.storage API when cloudflare / miniflare isn't injecting its own `VERSION` constant (e.g. in unit tests).
