### PR TITLE
feat: add token issuer to validateFromCaps result

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -63,7 +63,7 @@ export class Service {
       throw new Error('Invalid UCAN: Root issuer does not match this service.')
     }
 
-    return caps[0]
+    return { ...caps[0], issuer: token.issuer() }
   }
 
   did() {


### PR DESCRIPTION
Just adds token `issuer` to the return value of the `validateFromCaps` so it can be used for rate-limiting as per https://github.com/nftstorage/nft.storage/issues/2092