### PR TITLE
chore: fix save keypair example in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,7 @@ import { KeyPair } from 'ucan-storage/keypair'
 
 async function createAndSaveKeypair(outputFilename) {
   const kp = await KeyPair.create()
-  await fs.promises.writeFile(kp.export())
+  await fs.promises.writeFile(outputFilename, kp.export())
   return kp
 }
 


### PR DESCRIPTION
Closes #30 by adding the missing output filename param to `fs.writeFile`.